### PR TITLE
Make --help display the possible values of --compression option

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -5,39 +5,15 @@ use flate2::Compression;
 use std::io::Write;
 use std::str::FromStr;
 use structopt::StructOpt;
+use structopt::clap::arg_enum;
 
-#[derive(StructOpt, Debug, Clone, Copy)]
-pub enum CompressionFlag {
-    Off = 0x00,
-    ZSTD = 0x0D,
-    Zlib = 0x0E,
-}
-
-impl FromStr for CompressionFlag {
-    type Err = String;
-
-    fn from_str(compression: &str) -> std::result::Result<Self, Self::Err> {
-        match compression.to_lowercase().as_ref() {
-            "off" => Ok(CompressionFlag::Off),
-            "zstd" => Ok(CompressionFlag::ZSTD),
-            "zlib" => Ok(CompressionFlag::Zlib),
-            _ => Err(format!("Invalid compression: {}", compression)),
-        }
-    }
-}
-
-impl fmt::Display for CompressionFlag {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                CompressionFlag::Off => "off".to_string(),
-                CompressionFlag::ZSTD => "zstd".to_string(),
-                CompressionFlag::Zlib => "zlib".to_string(),
-            }
-        )
-    }
+arg_enum! {
+	#[derive(StructOpt, Debug, Clone, Copy)]
+	pub enum CompressionFlag {
+    	Off = 0x00,
+    	ZSTD = 0x0D,
+    	Zlib = 0x0E,
+	}
 }
 
 impl CompressionFlag {

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ pub struct Input {
     upload_my_drive: bool,
 
     /// Which compression should be used for the index file
-    #[structopt(long, default_value = "zstd")]
+    #[structopt(long, possible_values = &CompressionFlag::variants(), case_insensitive = true, default_value = "zstd")]
     compression: CompressionFlag,
 
     /// If OAuth should be done headless


### PR DESCRIPTION
Change the `structopt` and `clap` directives to auto-generate the prompt with correct values for `--compression` command line option, and parse and validate them.
Based on question at https://stackoverflow.com/q/59115832 and specifically on answer https://stackoverflow.com/a/61164893 from user https://stackoverflow.com/users/1327915/ticky (may require comment directly in the affected files depending on your understanding of https://stackoverflow.blog/2009/06/25/attribution-required/).
Related doc pages: 
https://docs.rs/clap/2.33.0/clap/struct.Arg.html#method.possible_values
https://docs.rs/clap/2.33.3/clap/macro.arg_enum.html