### PR TITLE
Camel case actual fix

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -17,7 +17,9 @@ pub struct Index {
     pub version: Option<f64>,
     pub client_cert_pub: Option<String>,
     pub client_cert_key: Option<String>,
+    #[serde(rename = "themeBlackList")]
     pub theme_blacklist: Option<Vec<String>>,
+    #[serde(rename = "themeWhiteList")]
     pub theme_whitelist: Option<Vec<String>>,
     pub theme_error: Option<String>,
 }


### PR DESCRIPTION
theme_blacklist should become themeBlackList and theme_whitelist should become themeWhiteList in the index.
Added serde directives to rename the fields in the index without changing interface.
Actually tested with Tinfoil and black/white lists do work.
All other fields seem to be named correctly to the doc.