### PR TITLE
Fix gdrive_api.rs:373:22:called `Option::unwrap()` on a `None` value 

### DIFF
--- a/rustfoil-lib/src/gdrive/gdrive_api.rs
+++ b/rustfoil-lib/src/gdrive/gdrive_api.rs
@@ -36,7 +36,7 @@ impl GoogleDriveApiService {
         let hub = DriveHub::new(
             hyper::Client::builder().build(
                 hyper_rustls::HttpsConnectorBuilder::new()
-                    .with_native_roots()
+                    .with_native_roots()?
                     .https_or_http()
                     .enable_http1()
                     .build(),
@@ -365,12 +365,12 @@ impl GoogleDriveApiService {
                     .1
             }
         };
-
+        
         let is_shared = self.is_file_shared(&res).await?;
 
         Ok(GoogleDriveFileInfo::new(
             res.id.unwrap(),
-            res.size.unwrap(),
+            res.size.unwrap_or(0),
             res.name.unwrap(),
             is_shared,
         ))


### PR DESCRIPTION
```console
[2025-01-28T19:48:39Z INFO  rustfoil_cli] Generating Index for 1 Google Drive Folders
[2025-01-28T19:48:39Z INFO  rustfoil_cli] Scanning Google Drive... this may take a while
[2025-01-28T19:48:53Z INFO  rustfoil_cli] Scanned a total of 967 file(s) & 16 folder(s)
[2025-01-28T19:48:53Z INFO  rustfoil_cli] Index file generated at "/var/www/gshop/index.tfl", using no compression & no encryption
thread 'main' panicked at /home/runner/work/rustfoil/rustfoil/rustfoil-lib/src/gdrive/gdrive_api.rs:373:22:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

after fix : 

```console
[2025-01-28T20:08:10Z INFO  rustfoil_cli] Generating Index for 1 Google Drive Folders
[2025-01-28T20:08:10Z INFO  rustfoil_cli] Scanning Google Drive... this may take a while
[2025-01-28T20:08:27Z INFO  rustfoil_cli] Scanned a total of 967 file(s) & 16 folder(s)
[2025-01-28T20:08:27Z INFO  rustfoil_cli] Index file generated at "/var/www/gshop/index.tfl", using no compression & no encryption
[2025-01-28T20:08:30Z INFO  rustfoil_cli] Uploaded Index to doidela
[2025-01-28T20:08:30Z INFO  rustfoil_cli] Execution took 00:00:19
```